### PR TITLE
feat: support frontmatter's filename when converting wikilinks

### DIFF
--- a/plugin/publishing/filesManagement.ts
+++ b/plugin/publishing/filesManagement.ts
@@ -137,10 +137,22 @@ export class FilesManagement extends Publisher {
 						file.path
 					);
 					if (linkedFile) {
+						const frontmatter = this.metadataCache.getCache(linkedFile.path).frontmatter;
+						let frontmatterDestinationFilePath;
+
+						/**
+						 * In case there's a frontmatter configuration, pass along
+						 * `filename` so we can later use that to convert wikilinks.
+						 */
+						if (frontmatter) {
+							frontmatterDestinationFilePath = frontmatter.filename;
+						}
+
 						embedList.push({
 							linked: linkedFile,
 							linkFrom: embedCache.link,
-							altText: embedCache.displayText
+							altText: embedCache.displayText,
+							destinationFilePath: frontmatterDestinationFilePath
 						})
 					}
 				} catch (e) {

--- a/plugin/settings/interface.ts
+++ b/plugin/settings/interface.ts
@@ -91,6 +91,7 @@ export interface LinkedNotes {
 	linked: TFile,
 	linkFrom: string,
 	altText: string,
+	destinationFilePath?: string,
 }
 
 export interface ConvertedLink {


### PR DESCRIPTION
The plugin supports settings a `filename` in frontmatter, which moves filepective file to that path. However, when wikilinks are converted to final paths, they completely ignore the frontmatter's `filename` entry.

Ideally, we would have an object that is responsible for returning the final, canonical paths (and some automated tests :). The simpler fix, though, was making sure the frontmatter's `filename` was present when we compile the list of linked files (`destinationFilePath`). When we're converting links inside `convertWikilinks()`, we can check whether it exists and use it, otherwise keep execution as it was previously.

A secondary problem is that the `convertWikilinks` function, which fetches files from the cache, wasn't removing the `./` from its beginning. In other words, for some reason, the linked file was `./some-name.md`, and it wouldn't match `some-name.md`, which was present in the cache.

This commit fixes those two problems. It should not break current behavior.

p.s. it's still not appending the base file path (e.g in my case `obsidian/`), but I'm solving that problem locally by using a regex and converting the final link.