### PR TITLE
Add RegExp multiline flag to Text Replacer

### DIFF
--- a/plugin/contents_conversion/findAndReplaceText.ts
+++ b/plugin/contents_conversion/findAndReplaceText.ts
@@ -16,7 +16,7 @@ export default function findAndReplaceText(text: string, settings: GitHubPublish
 		censoring = settings.censorText.filter(censor => censor.after);
 	}
 	for (const censor of censoring) {
-		const regex = new RegExp(censor.entry, 'ig');
+		const regex = new RegExp(censor.entry, 'mig');
 		// @ts-ignore
 		text = text.replaceAll(regex, censor.replace);
 	}


### PR DESCRIPTION
Allow matching start/end of lines in multiline strings by enabling [the multiline flag](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/multiline)

See #51