### PR TITLE
feat(embed): introduce "bake embed"

### DIFF
--- a/src/conversion/bakeEmbed.ts
+++ b/src/conversion/bakeEmbed.ts
@@ -1,0 +1,197 @@
+/**
+ * The majority of the code was taken from obsidian-easy-bake
+ * @credit mgmeyers
+ * @source https://github.com/mgmeyers/obsidian-easy-bake
+ * @license GPL-3.0
+ * Each function is modified to fit the needs of this plugin, but citation are done in the code for each function
+ */
+
+import {
+	App,
+	BlockSubpathResult,
+	CachedMetadata,
+	HeadingSubpathResult,
+	parseLinktext,
+	resolveSubpath,
+	stringifyYaml,
+	TFile} from "obsidian";
+
+import {GitHubPublisherSettings, Repository} from "../settings/interface";
+import {isShared} from "../utils/data_validation_test";
+
+/**
+ * Apply the indent to the text
+ * @credit mgmeyers - easy bake plugin
+ * @source https://github.com/mgmeyers/obsidian-easy-bake/blob/master/src/BakeModal.ts
+ * @param {string} text
+ * @param {string} indent
+ * @return {string}
+ */
+function applyIndent(text: string, indent?: string) {
+	if (!indent) return text;
+	return text.trim().replace(/(\r?\n)/g, `$1${indent}`);
+}
+
+/**
+ * Strip the first bullet from the string
+ * @credit mgmeyers - easy bake plugin
+ * @source https://github.com/mgmeyers/obsidian-easy-bake/blob/master/src/BakeModal.ts
+ * @param {string} text the text to convert
+ * @return {string}
+ */
+function stripFirstBullet(text: string) {
+	return text.replace(/^[ \t]*(?:[-*+]|[0-9]+[.)]) +/, "");
+}
+
+/**
+ * Dedent the string
+ * @credit mgmeyers - easy bake plugin
+ * @source https://github.com/mgmeyers/obsidian-easy-bake/blob/master/src/util.ts
+ * @param {string} str
+ * @return {string}
+ */
+function dedent(str: string) {
+	const firstIndent = str.match(/^([ \t]*)/);
+	if (firstIndent) {
+		return str.replace(
+			// Escape tab chars
+			new RegExp(`^${firstIndent[0].replace(/\\/g, "\\$&")}`, "gm"),
+			""
+		);
+	}
+	return str;
+}
+
+/**
+ * Strip the block id from the string
+ * @credit mgmeyers - easy bake plugin
+ * @source https://github.com/mgmeyers/obsidian-easy-bake/blob/master/src/util.ts
+ * @param {string} str
+ * @return {string}
+ */
+function stripBlockId(str: string) {
+	return str.replace(/ +\^[^ \n\r]+$/gm, "");
+}
+
+/**
+ * Extract the subpath from the content
+ * @credit mgmeyers - easy bake plugin
+ * @source https://github.com/mgmeyers/obsidian-easy-bake/blob/master/src/util.ts
+ * @param {string} content
+ * @param { HeadingSubpathResult|BlockSubpathResult } subpathResult
+ * @param {CachedMetadata} cache
+ * @return {string}
+ */
+function extractSubpath(
+	content: string,
+	subpathResult: HeadingSubpathResult | BlockSubpathResult,
+	cache: CachedMetadata
+) {
+	let text = content;
+
+	if (subpathResult.type === "block" && subpathResult.list && cache.listItems) {
+		const targetItem = subpathResult.list;
+		const ancestors = new Set<number>([targetItem.position.start.line]);
+		const start = targetItem.position.start.offset - targetItem.position.start.col;
+
+		let end = targetItem.position.end.offset;
+		let found = false;
+
+		for (const item of cache.listItems) {
+			if (targetItem === item) {
+				found = true;
+				continue;
+			} else if (!found) {
+				// Keep seeking until we find the target
+				continue;
+			}
+
+			if (!ancestors.has(item.parent)) break;
+			ancestors.add(item.position.start.line);
+			end = item.position.end.offset;
+		}
+
+		text = stripBlockId(dedent(content.substring(start, end)));
+	} else {
+		const start = subpathResult.start.offset;
+		const end = subpathResult.end ? subpathResult.end.offset : content.length;
+		text = stripBlockId(content.substring(start, end));
+	}
+
+	return text;
+}
+
+/**
+ * Allow to includes embed directly in the markdown
+ * Note : All embedded contents will be added in the file, without checking the shared state and the repository
+ * @credit mgmeyers - easy bake plugin
+ * @link https://github.com/mgmeyers/obsidian-easy-bake
+ * @source https://github.com/mgmeyers/obsidian-easy-bake/blob/master/src/BakeModal.ts
+ * @param {TFile} originalFile
+ * @param {Set<TFile>} ancestor the ancestor files
+ * @param app {App}
+ * @param repo {Repository | null}
+ * @param settings {GitHubPublisherSettings} the global settings
+ * @param subpath {string|null} the subpath to extract, if any
+ * @param original
+ * @return {string} the converted text
+ */
+export async function bakeEmbeds(
+	originalFile: TFile,
+	ancestor: Set<TFile>,
+	app: App,
+	repo: Repository | null,
+	settings: GitHubPublisherSettings,
+	subpath: string|null,
+	original: boolean = true): Promise<string> {
+	const { vault, metadataCache } = app;
+	let text = await vault.cachedRead(originalFile);
+	//remove frontmatter from text
+
+	const cache = metadataCache.getFileCache(originalFile);
+	if (!cache) return text;
+	if (subpath) {
+		const resolvedSubPath = resolveSubpath(cache, subpath);
+		if (resolvedSubPath) {
+			text = extractSubpath(text, resolvedSubPath, cache);
+		}
+	} else if (!original && !subpath) {
+		const yaml = cache.frontmatter ? `---\n${stringifyYaml(cache.frontmatter)}---` : "";
+		text = text.replace(yaml, "");
+	}
+	const embeds = cache.embeds;
+	if (!embeds || embeds.length === 0) return text;
+	const targets = [...embeds];
+	targets.sort((a, b) => a.position.start.offset - b.position.start.offset);
+	const newAncestors = new Set(ancestor);
+	newAncestors.add(originalFile);
+	let posOffset = 0;
+	for (const embed of targets) {
+		const {path, subpath} = parseLinktext(embed.link);
+		const linked = metadataCache.getFirstLinkpathDest(path, originalFile.path);
+		if (linked === null || linked?.extension !== "md") continue;
+		const start = embed.position.start.offset + posOffset;
+		const end = embed.position.end.offset + posOffset;
+		const prevLen = end - start;
+
+		const before = text.substring(0, start);
+		const after = text.substring(end);
+
+		const replaceTarget = (replacement: string) => {
+			text = before + replacement + after;
+			posOffset += replacement.length - prevLen;
+		};
+
+		const frontmatter = metadataCache.getFileCache(linked)?.frontmatter;
+		const shared = isShared(frontmatter, settings, linked, repo);
+		const listMatch = before.match(/(?:^|\n)([ \t]*)(?:[-*+]|[0-9]+[.)]) +$/);
+		if (newAncestors.has(linked) || !shared) {
+			replaceTarget(embed.displayText || path);
+			continue;
+		}
+		const baked = await bakeEmbeds(linked, newAncestors, app, repo, settings, subpath, false);
+		replaceTarget(
+			listMatch ? applyIndent(stripFirstBullet(baked), listMatch[1]) : baked);
+	}
+	return text;
+}

--- a/src/conversion/convert_text.ts
+++ b/src/conversion/convert_text.ts
@@ -22,10 +22,10 @@ import {
 	Repository,
 } from "../settings/interface";
 import {log, noticeLog} from "../utils";
+import {bakeEmbeds} from "./bakeEmbed";
 import {getDataviewPath} from "./file_path";
 import findAndReplaceText from "./find_and_replace_text";
 import {convertLinkCitation, convertWikilinks, escapeRegex} from "./links";
-
 
 /**
  * Convert soft line breaks to hard line breaks, adding two space at the end of the line.
@@ -412,6 +412,8 @@ async function convertDataviewLinks(
 	return md;
 }
 
+
+
 /**
  * Main function to convert the text
  * @param {string} text the text to convert
@@ -443,6 +445,8 @@ export async function mainConverting(
 	sourceRepo: RepoFrontmatter | RepoFrontmatter[],
 	shortRepo: Repository | null
 ): Promise<string> {
+	if (settings.embed.convertEmbedToLinks === "bake")
+		text = await bakeEmbeds(file, new Set(), app, shortRepo, settings, null, true);
 	text = findAndReplaceText(text, settings, false);
 	text = await addInlineTags(settings, file, metadataCache, frontmatter, text);
 	text = await convertDataviewQueries(

--- a/src/conversion/file_path.ts
+++ b/src/conversion/file_path.ts
@@ -54,6 +54,7 @@ export function getDataviewPath(
 					linked: linked,
 					linkFrom: linkFrom,
 					altText: altText,
+					type: "link"
 				});
 			}
 		}
@@ -98,7 +99,7 @@ export async function createRelativePath(
 		frontmatterSettings
 	);
 	if (
-		targetFile.linked.extension === "md" && (isFromAnotherRepo === false || shared === false)
+		targetFile.linked.extension === "md" && (!isFromAnotherRepo || !shared)
 	) {
 		return targetFile.destinationFilePath ? targetFile.destinationFilePath: targetFile.linked.basename;
 	}

--- a/src/conversion/links.ts
+++ b/src/conversion/links.ts
@@ -88,7 +88,7 @@ export function convertWikilinks(
 							.replace(/ > \^\w*/, "");
 					}
 					const removeEmbed =
-						conditionConvert.removeEmbed === "remove" &&
+						(conditionConvert.removeEmbed === "remove" || conditionConvert.removeEmbed === "bake") &&
 						isEmbedBool &&
 						linkedFile.linked.extension === "md";
 					if (isEmbedBool && linkedFile.linked.extension === "md" && conditionConvert.removeEmbed === "links") {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -103,8 +103,8 @@
     "scanningRepo": "Scanning the repository, may take a while...",
     "sendMessage": "Upload {{- nbNotes}} notes to {{- repo.owner}}/{{- repo.repo}}",
     "startingClean": "Starting cleaning {{- repo.owner}}/{{- repo.repo}}",
-    "successfulPublish": "Successfully uploaded {{- nbNotes}} to {{- repo.owner}}/{{- repo.repo}}",
     "successPublishOneNote": "Successfully uploaded {{- file}} to {{- repo.owner}}/{{- repo.repo}}",
+    "successfulPublish": "Successfully uploaded {{- nbNotes}} to {{- repo.owner}}/{{- repo.repo}}",
     "waitingWorkflow": "Now, waiting for the workflow to be completed..."
   },
   "modals": {
@@ -212,6 +212,7 @@
       "links": {
         "desc": "Allow to edit the links of the embeds, removing entirely the citation, or transform to a simple link",
         "dp": {
+          "bake": "Include embed contents",
           "keep": "No change",
           "links": "Transform to link",
           "remove": "Remove link completely"

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -103,8 +103,8 @@
     "scanningRepo": "Scan du dépôt, veuillez patienter...",
     "sendMessage": "Transfert de {{- nbNotes}} notes vers {{- repo.owner}}/{{- repo.repo}}",
     "startingClean": "Début du nettoyage de {{- repo.owner}}/{{- repo.repo}}",
-    "successfulPublish": "Transfert réussi de {{- nbNotes}} notes vers {{- repo.owner}}/{{- repo.repo}}",
     "successPublishOneNote": "Transfert réussi de {{- file}} vers {{- repo.owner}}/{{- repo.repo}}",
+    "successfulPublish": "Transfert réussi de {{- nbNotes}} notes vers {{- repo.owner}}/{{- repo.repo}}",
     "waitingWorkflow": "Maintenant, attente de la fin du workflow..."
   },
   "modals": {
@@ -212,6 +212,7 @@
       "links": {
         "desc": "Permet d'éditer les liens des embeds, en supprimant entièrement la citation, ou en la transformant en un simple lien.",
         "dp": {
+          "bake": "Inclure le contenu des embeds",
           "keep": "Pas de changement",
           "links": "Transformer en lien simple",
           "remove": "Supprimer le lien complètement"

--- a/src/publish/files.ts
+++ b/src/publish/files.ts
@@ -193,6 +193,11 @@ export class FilesManagement extends Publisher {
 							linkFrom: image.link, //path of the founded file
 							altText, //alt text if exists, filename otherwise
 							destinationFilePath: frontmatterDestinationFilePath,
+							type: "embed",
+							position: {
+								start: image.position.start.offset,
+								end: image.position.end.offset,
+							}
 						};
 						if (image.link.includes("#")) {
 							thisLinkedFile.anchor = "#" + image.link.split("#")[1];
@@ -249,6 +254,7 @@ export class FilesManagement extends Publisher {
 							linkFrom: embedCache.link,
 							altText,
 							destinationFilePath: frontmatterDestinationFilePath,
+							type: "link",
 						};
 						if (embedCache.link.includes("#")) {
 							thisEmbed.anchor = "#" + embedCache.link.split("#")[1];

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -817,7 +817,7 @@ export class GithubPublisherSettingsTab extends PluginSettingTab {
 					});
 			});
 
-		new Setting(this.settingsPage)
+		const embedNote = new Setting(this.settingsPage)
 			.setName(i18next.t("settings.embed.transferNotes.title"))
 			.setDesc(i18next.t("settings.embed.transferNotes.desc"))
 			.addToggle((toggle) => {
@@ -831,7 +831,6 @@ export class GithubPublisherSettingsTab extends PluginSettingTab {
 			});
 
 		if (embedSettings.notes) {
-			//@TODO translate this
 			new Setting(this.settingsPage)
 				.setName(i18next.t("settings.embed.links.title"))
 				.setDesc(i18next.t("settings.embed.links.desc"))
@@ -840,9 +839,10 @@ export class GithubPublisherSettingsTab extends PluginSettingTab {
 						.addOption("keep", i18next.t("settings.embed.links.dp.keep"))
 						.addOption("remove", i18next.t("settings.embed.links.dp.remove"))
 						.addOption("links", i18next.t("settings.embed.links.dp.links"))
+						.addOption("bake", i18next.t("settings.embed.links.dp.bake"))
 						.setValue(embedSettings.convertEmbedToLinks ?? "keep")
 						.onChange(async (value) => {
-							embedSettings.convertEmbedToLinks = value as "keep" | "remove" | "links";
+							embedSettings.convertEmbedToLinks = value as "keep" | "remove" | "links" | "bake";
 							await this.plugin.saveSettings();
 							this.renderEmbedConfiguration();
 						});

--- a/src/settings/interface.ts
+++ b/src/settings/interface.ts
@@ -111,7 +111,7 @@ export interface GitHubPublisherSettings {
 		keySendFile: string[];
 		notes: boolean;
 		folder: string;
-		convertEmbedToLinks: "links" | "remove" | "keep";
+		convertEmbedToLinks: "links" | "remove" | "keep" | "bake";
 		charConvert: string;
 	}
 	plugin:
@@ -264,6 +264,11 @@ export interface LinkedNotes {
 	altText?: string;
 	destinationFilePath?: string;
 	anchor?: string;
+	type: "embed" | "link";
+	position?: {
+		start: number;
+		end: number;
+	}
 }
 
 export interface ConvertedLink {
@@ -291,7 +296,7 @@ export interface FrontmatterConvert {
 	embed: boolean;
 	attachmentLinks: string;
 	convertWiki: boolean;
-	removeEmbed: "keep" | "remove" | "links";
+	removeEmbed: "keep" | "remove" | "links" | "bake";
 	charEmbedLinks: string;
 	dataview: boolean;
 	hardbreak: boolean;

--- a/src/utils/data_validation_test.ts
+++ b/src/utils/data_validation_test.ts
@@ -1,5 +1,5 @@
 import i18next from "i18next";
-import {FrontMatterCache, MetadataCache,Notice, TFile } from "obsidian";
+import {FrontMatterCache, MetadataCache, Notice, TFile} from "obsidian";
 import GithubPublisher from "src/main";
 
 import {GithubBranch} from "../publish/branch";
@@ -21,7 +21,7 @@ export function isInternalShared(
 	const shared =
 		frontmatter && frontmatter[sharekey] ? frontmatter[sharekey] : false;
 	if (shared) return true;
-	return !shared && frontmatterSettings.convertInternalNonShared === true;
+	return !shared && frontmatterSettings.convertInternalNonShared;
 }
 
 export function getRepoSharedKey(settings: GitHubPublisherSettings, frontmatter?: FrontMatterCache): Repository | null{

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -398,6 +398,8 @@ function translateBooleanForRemoveEmbed(removeEmbed: unknown) {
 		return "remove";
 	} else if (removeEmbed === "links") {
 		return "links";
+	} else if (removeEmbed === "bake" || removeEmbed === "include") {
+		return "bake";
 	} else return "keep";
 }
 


### PR DESCRIPTION
Thanks to @mgmeyers

it allows to add the contents of the embed in the file directly, like in [easy-bake plugin](https://github.com/mgmeyers/obsidian-easy-bake).

The contents are added "as in", without specific markdown (like >).

A new option is added in the settings to allow that. To use it with front matter, user need to use "bake" or "include", like:

```yaml
removeEmbed: "bake"
```
or
```yaml
embed:
 remove: "bake"
```

See #190