### PR TITLE
Set "isShared" true, if the shareKey is empty && file does not start with DRAFT

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -431,7 +431,7 @@
         "title": "Notice every error"
       },
       "shareKey": {
-        "desc": "The properties key to publish your file on the website.",
+        "desc": "The properties key to publish your file on the website. (If left empty, all files not starting with 'DRAFT' or in excludedFolders will be published)",
         "otherRepo": "You can also define a share key to separate with others, without using the shortRepo key.",
         "title": "Share Key"
       },

--- a/src/utils/data_validation_test.ts
+++ b/src/utils/data_validation_test.ts
@@ -54,15 +54,18 @@ export function isShared(
 	if (!file || file.extension !== "md" || meta === null) {
 		return false;
 	}
-	const folderList = settings.plugin.excludedFolder;
+	const excludedFolderList = settings.plugin.excludedFolder;
 	const shareKey = otherRepo ? otherRepo.shareKey : settings.plugin.shareKey;
+	if (shareKey === "" && !file.basename.startsWith("DRAFT")) {
+		return true;
+	}
 	if (meta === undefined || meta[shareKey] === undefined) {
 		return false;
-	} else if (folderList.length > 0) {
-		for (let i = 0; i < folderList.length; i++) {
-			const isRegex = folderList[i].match(/^\/(.*)\/[igmsuy]*$/);
+	} else if (excludedFolderList.length > 0) {
+		for (let i = 0; i < excludedFolderList.length; i++) {
+			const isRegex = excludedFolderList[i].match(/^\/(.*)\/[igmsuy]*$/);
 			const regex = isRegex ? new RegExp(isRegex[1], isRegex[2]) : null;
-			if ((regex && regex.test(file.path)) || file.path.contains(folderList[i].trim())) {
+			if ((regex && regex.test(file.path)) || file.path.contains(excludedFolderList[i].trim())) {
 				return false;
 			}
 		}


### PR DESCRIPTION
Hello Lisandra.
I would like to propose this solution as possible inclusion in the plugin, for people that would like to not pollute their frontmatter with plugin information irrelevant to file contents.
It is an answer to this suggestion: https://github.com/orgs/ObsidianPublisher/discussions/207

And a small var rename for better readability by contributors