### PR TITLE
feat: allow same link transformation for other repo

### DIFF
--- a/src/settings/interface.ts
+++ b/src/settings/interface.ts
@@ -46,6 +46,14 @@ export interface Repository {
 	copyLink: {
 		links: string;
 		removePart: string[];
+		transform: {
+			toUri: boolean;
+			slugify: "lower" | "strict" | "disable";
+			applyRegex: {
+				regex: string;
+				replacement: string;
+			}[]
+		}
 	}
 
 }

--- a/src/settings/modals/manage_repo.ts
+++ b/src/settings/modals/manage_repo.ts
@@ -67,7 +67,12 @@ export class ModalAddingNewRepository extends Modal {
 			shareKey: this.settings.plugin.shareKey,
 			copyLink: {
 				links: this.settings.plugin.copyLink.links,
-				removePart: []
+				removePart: [],
+				transform: {
+					toUri: this.settings.plugin.copyLink.transform.toUri,
+					slugify: this.settings.plugin.copyLink.transform.slugify,
+					applyRegex: this.settings.plugin.copyLink.transform.applyRegex
+				}
 			}
 		};
 
@@ -427,6 +432,87 @@ class ModalEditingRepository extends Modal {
 							await this.plugin.saveSettings();
 						});
 				});
+			
+			new Setting(contentEl)
+				.setName(i18next.t("settings.plugin.copyLink.toUri.title"))
+				.setDesc(i18next.t("settings.plugin.copyLink.toUri.desc"))
+				.addToggle((toggle) =>
+					toggle
+						.setValue(this.repository.copyLink.transform.toUri)
+						.onChange(async (value) => {
+							this.repository.copyLink.transform.toUri = value;
+							await this.plugin.saveSettings();
+						})
+				);
+			
+			new Setting(contentEl)
+				.setName(i18next.t("settings.plugin.copyLink.slugify.title"))
+				.addDropdown((dropdown) => {
+					dropdown
+						.addOptions({
+							disable: i18next.t("settings.plugin.copyLink.slugify.disable"),
+							strict: i18next.t("settings.plugin.copyLink.slugify.strict"),
+							lower: i18next.t("settings.plugin.copyLink.slugify.lower"),
+						})
+						.setValue(this.repository.copyLink.transform.slugify as "disable" | "strict" | "lower")
+						.onChange(async (value) => {
+							this.repository.copyLink.transform.slugify = value as "disable" | "strict" | "lower";
+							await this.plugin.saveSettings();
+						});
+				});
+		
+			new Setting(contentEl)
+				.setName(i18next.t("settings.plugin.copyLink.applyRegex.title"))
+				.setHeading()
+				.setDesc(i18next.t("settings.plugin.copyLink.applyRegex.desc"))
+				.addExtraButton((button) => {
+					button
+						.setIcon("plus")
+						.onClick(async () => {
+							this.repository.copyLink.transform.applyRegex.push({
+								regex: "",
+								replacement: ""
+							});
+							await this.plugin.saveSettings();
+							this.onOpen();
+						});
+				});
+
+			for (const apply of this.repository.copyLink.transform.applyRegex) {
+				const regex = apply.regex;
+				const replacement = apply.replacement;
+
+				new Setting(contentEl)
+					.setClass("no-display")
+					.addText((text) => {
+						text
+							.setPlaceholder("regex")
+							.setValue(regex)
+							.onChange(async (value) => {
+								apply.regex = value;
+								await this.plugin.saveSettings();
+							});
+					})
+					.setClass("max-width")
+					.addText((text) => {
+						text
+							.setPlaceholder("replacement")
+							.setValue(replacement)
+							.onChange(async (value) => {
+								apply.replacement = value;
+								await this.plugin.saveSettings();
+							});
+					})
+					.setClass("max-width")
+					.addExtraButton(button => {
+						button.setIcon("trash")
+							.onClick(async () => {
+								this.repository.copyLink.transform.applyRegex = this.repository.copyLink.transform.applyRegex.filter((item) => item !== apply);
+								await this.plugin.saveSettings();
+								this.onOpen();
+							});
+					});	
+			}	
 		}
 
 		new Setting(contentEl)

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -227,16 +227,6 @@ function checkSlash(link: string): string {
 }
 
 /**
- * Fix multiple/toomuch slash in URL
- * @example https://www.xxxx.com//filename///removed -> https://www.xxxx.com/filename/removed
- * @param link {string} - the link to fix
- * @returns the fixed link {string}
- */
-function fixSlashInURL(link: string): string {
-	return link.replace(/([^:]\/)\/+/g, "$1");
-}
-
-/**
  * Create the link for the file and add it to the clipboard
  * The path is based with the receipt folder but part can be removed using settings.
  * By default, use a github.io page for the link.
@@ -306,7 +296,7 @@ export async function createLink(
 		}
 	}
 	//fix links like double slash
-	await navigator.clipboard.writeText(fixSlashInURL(url));
+	await navigator.clipboard.writeText(url.replace(/([^:]\/)\/+/g, "$1"));
 	return;
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced URL transformation settings for copying repository links, including options to convert to URI, slugify, and apply regex patterns.
- **Bug Fixes**
	- Fixed an issue where copied URLs contained double slashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->