### PR TITLE
Add  prefix to custom ID

### DIFF
--- a/src/conversion/links.ts
+++ b/src/conversion/links.ts
@@ -203,7 +203,7 @@ function createMarkdownLinks(fileName: string, isEmbed: string, altLink: string,
 		? fileName.replace(/#.*/, "").trim() + ".md"
 		: fileName.trim();
 	const anchorMatch = fileName.match(/(#.*)/);
-	let anchor = anchorMatch ? anchorMatch[0] : null;
+	let anchor = anchorMatch ? anchorMatch[0].replace(/^#\^/, "user-content-") : null;
 	const encodedURI = encodeURI(markdownName);
 	anchor = slugifyAnchor(anchor, settings);
 	return `${isEmbed}[${altLink}](${encodedURI}${anchor})`;

--- a/src/conversion/links.ts
+++ b/src/conversion/links.ts
@@ -203,7 +203,7 @@ function createMarkdownLinks(fileName: string, isEmbed: string, altLink: string,
 		? fileName.replace(/#.*/, "").trim() + ".md"
 		: fileName.trim();
 	const anchorMatch = fileName.match(/(#.*)/);
-	let anchor = anchorMatch ? anchorMatch[0].replace(/^#\^/, "user-content-") : null;
+	let anchor = anchorMatch ? anchorMatch[0].replace(/^#\^/, "user-content-^") : null;
 	const encodedURI = encodeURI(markdownName);
 	anchor = slugifyAnchor(anchor, settings);
 	return `${isEmbed}[${altLink}](${encodedURI}${anchor})`;


### PR DESCRIPTION
This proposal converts `[[note#^identifier]]` into `[altLink](note#user-content-^identifier)` instead of `[altLink](note#^identifier)`

## Background

I have the following conversion. It converts a block identifier, e.g. `^37066d` at the end of a paragraph into `<a id="^37066d"></a>`. (AFAIK, this plugin does not support such conversion natively.)

```json
"censorText": [
  {
    "entry": "/ \\^(\\w+)$/gm",
    "replace": " <a id=\"^$1\"></a>",
    "flags": "",
    "after": false
  }
]
```

However, when GitHub renders the file on the web browser, it add `user-content-` prefix to the ID. (I guess they try to avoid ID duplication/collision.)

So a link to a block, e.g. `[[note#^identifier]]`, would not work after publishing to GitHub since such an anchor does no longer exist due to GitHub markdown renderer.
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

"""
- **Bug Fixes**
	- Improved the generation of markdown links to ensure correct anchoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->