### PR TITLE
docs: clarify vault sync warning with alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Here, you will only get a quick setup!
 - And many more :sparkles:
 
 > [!WARNING]
-> Do not use this plugin to sync or save your Obsidian Vault!
+> Do not use this plugin to sync your Obsidian Vault across devices! Consider using [Obsidian Sync](https://obsidian.md/sync) or [obsidian-livesync](https://github.com/vrtmrz/obsidian-livesync) for those purposes instead.
 > Avoid opening the converted files from your repository in Obsidian!
 
 ---


### PR DESCRIPTION
Clarify that Enveloppe should not be used for syncing vaults across devices, and suggest Obsidian Sync and obsidian-livesync as proper alternatives for that use case.