### PR TITLE
fix: frontmatter links not transforming correctly

### DIFF
--- a/src/GitHub/files.ts
+++ b/src/GitHub/files.ts
@@ -7,7 +7,13 @@ import type {
 	Repository,
 } from "@interfaces/main";
 import type { Octokit } from "@octokit/core";
-import { type EmbedCache, type LinkCache, TFile, TFolder } from "obsidian";
+import {
+	type EmbedCache,
+	type LinkCache,
+	type Reference,
+	TFile,
+	TFolder,
+} from "obsidian";
 import { getAPI, type Link } from "obsidian-dataview";
 import { getImagePath, getReceiptFolder } from "src/conversion/file_path";
 import Publisher from "src/GitHub/upload";
@@ -240,7 +246,11 @@ export class FilesManagement extends Publisher {
 	 * @return {LinkedNotes[]} the file linked (TFile), the path to it, and the alt text if exists
 	 */
 	getLinkedFiles(file: TFile): LinkedNotes[] {
-		const embedCaches = this.metadataCache.getCache(file.path)?.links;
+		const bodyEmbedCaches: Reference[] =
+			this.metadataCache.getCache(file.path)?.links ?? [];
+		const frontmatterEmbedCaches: Reference[] =
+			this.metadataCache.getCache(file.path)?.frontmatterLinks ?? [];
+		const embedCaches: Reference[] = bodyEmbedCaches.concat(frontmatterEmbedCaches);
 		const embedList: LinkedNotes[] = [];
 		if (embedCaches != undefined) {
 			for (const embedCache of embedCaches) {


### PR DESCRIPTION
Two things to note here:

1. The underlying cause is the `.links` property on the metadata cache only fetches links in the body of the note. Further down the pipeline, when the wikilink rewrite happens, the frontmatter links aren't in the list so they don't get rewritten at all. The fix is to also grab the frontmatter links and combine the list together.

2. I cast the result to `Reference[]` because the actual type of `.links` & `.frontmatterLinks` are different from each other (`LinkCache` vs `FrontmatterLinkCache`). However, they both extend eventually from `Reference`, and the downstream logic doesn't require any of the properties that are specific to `LinkCache`. So we can leave the processing as-is while TypeScript stays happy.

We could remove the `if (embedCaches != undefined)` check but I left it to keep the diff small & focused on the relevant logic changes.

Fixes #406.