### PR TITLE
Adding extra documentation link to ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Before you begin, you will need to configure your GitHub repository.
 5. Now, run the command to publish: `Upload single current active note`
 6. If everything is good, a PR will be created on your repository and will be automatically merged (this can be disabled if desired!).
 
-That's it! However, there are many options that a simple README cannot cover, so please refer to the documentation for more information. 💕.
+That's it! However, there are many options that a simple README cannot cover, so please refer to the [documentation](https://enveloppe.ovh/) for more information. 💕.
 
 ## ⚙️ Usage
 


### PR DESCRIPTION
When reading the ReadMe, I didn't initially notice the header documentation link, but I did notice text telling me to check the documentation with no link near it. I figure this will help more people see the documentation with less effort.