### PR TITLE
Fix link to commands in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The plugin adds 8 commands in the palette, one of which is also available in the
 - `Test the connection to the configured repository`
 - `Check the rate limit of the GitHub API`
 
-Each of the commands are explained [here](https://enveloppe.ovh/Commands).
+Each of the commands are explained [here](https://enveloppe.ovh/Getting%20Started/Commands/).
 
 ## 🤖 How it works
 


### PR DESCRIPTION
The page at https://enveloppe.ovh/Commands is blank:

<img width="1896" height="953" alt="image" src="https://github.com/user-attachments/assets/34b8eef5-e05e-4bff-b8a3-b03b5cb323bc" />

I'm guessing this is because it was moved to https://enveloppe.ovh/Getting%20Started/Commands/ as is linked at the bottom of the ReadMe, so I changed the link to match.