### PR TITLE
fix: slugify anchor strict duplicating anchor symbols

### DIFF
--- a/src/conversion/links.ts
+++ b/src/conversion/links.ts
@@ -280,10 +280,10 @@ function createMarkdownLinks(
 		ext = "";
 	}
 
-	const anchorMatch = fileName.match(/(#.*)/);
+	const anchorMatch = fileName.match(/#(.*)/);
 	let anchor = anchorMatch ? anchorMatch[0] : null;
 	const encodedUri = `${slugifyAnchor(markdownName.replace(ext, ""), settings, true)}${ext}`;
-	anchor = slugifyAnchor(anchor, settings);
+	anchor = anchorMatch ? '#' + slugifyAnchor(anchor, settings) : null;
 	return `${isEmbed}[${altLink}](${encodedUri}${anchor})`;
 }
 
@@ -303,13 +303,12 @@ function slugifyAnchor(
 		typeof settings.conversion.links.slugifyAnchor === "string"
 			? settings.conversion.links.slugifyAnchor
 			: "disable";
-	const symbol = encode ? "" : "#";
 	if (anchor && slugifySetting !== "disable") {
 		switch (settings.conversion.links.slugifyAnchor) {
 			case "lower":
 				return anchor.toLowerCase().replaceAll(" ", "-");
 			case "strict":
-				return `${symbol}${slugify(anchor, { lower: true, strict: true })}`;
+				return `${slugify(anchor, { lower: true, strict: true })}`;
 
 			default:
 				return encode ? encodeURI(anchor) : anchor;

--- a/src/conversion/links.ts
+++ b/src/conversion/links.ts
@@ -281,9 +281,8 @@ function createMarkdownLinks(
 	}
 
 	const anchorMatch = fileName.match(/#(.*)/);
-	let anchor = anchorMatch ? anchorMatch[0] : null;
+	const anchor = anchorMatch ? '#' + slugifyAnchor(anchorMatch[0], settings) : '';
 	const encodedUri = `${slugifyAnchor(markdownName.replace(ext, ""), settings, true)}${ext}`;
-	anchor = anchorMatch ? '#' + slugifyAnchor(anchor, settings) : null;
 	return `${isEmbed}[${altLink}](${encodedUri}${anchor})`;
 }
 

--- a/src/conversion/links.ts
+++ b/src/conversion/links.ts
@@ -280,8 +280,8 @@ function createMarkdownLinks(
 		ext = "";
 	}
 
-	const anchorMatch = fileName.match(/#(.*)/);
-	const anchor = anchorMatch ? '#' + slugifyAnchor(anchorMatch[0], settings) : '';
+	const anchorMatch = fileName.match(/#.*/);
+	const anchor = anchorMatch ? slugifyAnchor(anchorMatch[0], settings) : '';
 	const encodedUri = `${slugifyAnchor(markdownName.replace(ext, ""), settings, true)}${ext}`;
 	return `${isEmbed}[${altLink}](${encodedUri}${anchor})`;
 }
@@ -296,25 +296,27 @@ function createMarkdownLinks(
 function slugifyAnchor(
 	anchor: string | null,
 	settings: EnveloppeSettings,
-	encode?: boolean
+	encode?: boolean,
 ): string {
-	const slugifySetting =
-		typeof settings.conversion.links.slugifyAnchor === "string"
-			? settings.conversion.links.slugifyAnchor
-			: "disable";
-	if (anchor && slugifySetting !== "disable") {
+	const anchorParts = anchor?.match(/^(#?)(.*)/);
+	if (anchorParts) {
+		const anchorSymbol = anchorParts[1];
+		let anchorText = anchorParts[2];
+
 		switch (settings.conversion.links.slugifyAnchor) {
 			case "lower":
-				return anchor.toLowerCase().replaceAll(" ", "-");
+				anchorText = anchorText.toLowerCase().replaceAll(" ", "-");
 			case "strict":
-				return `${slugify(anchor, { lower: true, strict: true })}`;
+				anchorText = `${slugify(anchorText, { lower: true, strict: true })}`;
 
 			default:
-				return encode ? encodeURI(anchor) : anchor;
+				anchorText = encode
+					? encodeURI(anchorText)
+					: anchorText.replaceAll(" ", "%20");
 		}
+		return anchorSymbol + anchorText;
 	}
-	if (!encode) return anchor?.replaceAll(" ", "%20") ?? "";
-	else return anchor ? encodeURI(anchor) : "";
+	return "";
 }
 
 /**
@@ -398,6 +400,7 @@ export async function convertToInternalGithub(
 				if (linkedFile.anchor) {
 					pathInGithub = pathInGithub.replace(/#.*/, "");
 					pathInGithubWithAnchor += linkedFile.anchor;
+					anchor = slugifyAnchor(anchor, settings);
 				}
 
 				let newLink = link.replace(regToReplace, pathInGithubWithAnchor);
@@ -406,8 +409,7 @@ export async function convertToInternalGithub(
 						linkedFile.linked.extension === "md" &&
 						!linkedFile.linked.name.includes("excalidraw")
 					) {
-						anchor = slugifyAnchor(anchor, settings);
-						pathInGithub = `${pathInGithub.replaceAll(" ", "%20")}.md#${anchor}`;
+						pathInGithub = `${pathInGithub.replaceAll(" ", "%20")}.md${anchor}`;
 						pathInGithub =
 							!pathInGithub.match(/(#.*)/) && !pathInGithub.endsWith(".md")
 								? `${pathInGithub}.md`


### PR DESCRIPTION
- rebased today onto current upstream
- PR does not / cannot fix related issues. E.g.
  - Encoding the link target sometimes with encodeURI() and sometimes by reusing the slugifyAnchor() function, resulting in different behaviour for the same context depending on the unreated anchor settings.
  - Stale conditions (meaning, there is code that can never be reached but makes it hard to read and test the different options). I removed them in slugifyAnchor() but didn't touch them anywhere else like in https://github.com/Enveloppe/obsidian-enveloppe/blob/a09138f48cf2176e2975ed8b7e21ede7d44c8200/src/conversion/links.ts#L412-L416
  - Why does it matter? I'm confident that this PR fixes the reported anchor issue, but I don't think the included encoding part is currently working as intended depending on the different plugin settings.

Related: https://github.com/Enveloppe/obsidian-enveloppe/issues/419
